### PR TITLE
refactored a lot of the active scene management code

### DIFF
--- a/src/seagulls/cli/_launch_command.py
+++ b/src/seagulls/cli/_launch_command.py
@@ -2,7 +2,8 @@ import logging
 from argparse import ArgumentParser
 from typing import Any, Dict
 
-from seagulls.engine import IGameSession
+from seagulls.engine import IGameSession, IGameScene
+from seagulls.examples import ISetActiveScene
 
 from ._framework import CliCommand
 
@@ -12,9 +13,28 @@ logger = logging.getLogger(__name__)
 class LaunchCommand(CliCommand):
 
     _game_session: IGameSession
+    _active_scene_manager: ISetActiveScene
 
-    def __init__(self, game_session: IGameSession):
+    _main_menu_scene: IGameScene
+    _space_shooter_scene: IGameScene
+    _seagulls_scene: IGameScene
+    _rpg_scene: IGameScene
+
+    def __init__(
+            self,
+            game_session: IGameSession,
+            active_scene_manager: ISetActiveScene,
+            main_menu_scene: IGameScene,
+            space_shooter_scene: IGameScene,
+            seagulls_scene: IGameScene,
+            rpg_scene: IGameScene):
         self._game_session = game_session
+        self._active_scene_manager = active_scene_manager
+
+        self._main_menu_scene = main_menu_scene
+        self._space_shooter_scene = space_shooter_scene
+        self._seagulls_scene = seagulls_scene
+        self._rpg_scene = rpg_scene
 
     def get_command_name(self) -> str:
         return "launch"
@@ -23,9 +43,24 @@ class LaunchCommand(CliCommand):
         return "Launch the _seagulls game."
 
     def configure_parser(self, parser: ArgumentParser) -> None:
-        pass
+        parser.add_argument(
+            "--scene",
+            choices=["space-shooter", "seagulls", "rpg"],
+            help="Load a scene and skip the main menu")
 
     def execute(self, args: Dict[str, Any]):
+        choice = args.get("scene")
+        if choice is None:
+            choice = "main-menu"
+
+        options = {
+            "main-menu": self._main_menu_scene,
+            "space-shooter": self._space_shooter_scene,
+            "seagulls": self._seagulls_scene,
+            "rpg": self._rpg_scene,
+        }
+        self._active_scene_manager.set_active_scene(options[choice])
+
         try:
             self._game_session.start()
             self._game_session.wait_for_completion()

--- a/src/seagulls/examples/__init__.py
+++ b/src/seagulls/examples/__init__.py
@@ -1,12 +1,24 @@
-from ._main_menu_scene import MainMenuScene
+from ._main_menu_scene import (
+    SpaceShooterMenuButton,
+    SeagullsMenuButton,
+    RpgMenuButton,
+    MainMenuScene
+)
 from ._scene_manager import ExampleSceneManager
 from ._session import AsyncGameSession, BlockingGameSession
 from ._simple_stars_background import SimpleStarsBackground
 from ._simple_rpg_background import SimpleRpgBackground
 from ._window_scene import WindowScene
-from ._game_state import GameState
+from ._active_scene_client import (
+    IProvideActiveScene,
+    ISetActiveScene,
+    ActiveSceneClient,
+)
 
 __all__ = [
+    "SpaceShooterMenuButton",
+    "SeagullsMenuButton",
+    "RpgMenuButton",
     "MainMenuScene",
     "AsyncGameSession",
     "BlockingGameSession",
@@ -14,5 +26,7 @@ __all__ = [
     "SimpleStarsBackground",
     "SimpleRpgBackground",
     "WindowScene",
-    "GameState"
+    "IProvideActiveScene",
+    "ISetActiveScene",
+    "ActiveSceneClient",
 ]

--- a/src/seagulls/examples/_active_scene_client.py
+++ b/src/seagulls/examples/_active_scene_client.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import Callable
+
+from seagulls.engine import IGameScene
+
+
+class IProvideActiveScene(ABC):
+
+    @abstractmethod
+    def apply(self, callback: Callable[[IGameScene], None]):
+        pass
+
+
+class ISetActiveScene(ABC):
+
+    @abstractmethod
+    def set_active_scene(self, scene: IGameScene) -> None:
+        pass
+
+
+class ActiveSceneClient(IProvideActiveScene, ISetActiveScene):
+
+    _active_scene: IGameScene
+
+    def __init__(self, scene: IGameScene):
+        self._active_scene = scene
+
+    def apply(self, callback: Callable[[IGameScene], None]):
+        callback(self._active_scene)
+
+    def set_active_scene(self, scene: IGameScene) -> None:
+        self._active_scene = scene

--- a/src/seagulls/examples/_game_state.py
+++ b/src/seagulls/examples/_game_state.py
@@ -1,9 +1,0 @@
-from typing import Optional
-
-from seagulls.engine import IGameScene
-
-
-class GameState:
-    active_scene: Optional[IGameScene] = None
-    game_state_changed: bool = False
-


### PR DESCRIPTION
We created a new object that allows us to change the active scene and to apply a callback to the active scene. Had to make a `EmptyScene` class in order to wire the entire DI Container up before we were ready to load the right scene we cared about, but this change also allowed us to give the `seagulls launch` command a new `--scene` argument that lets us skip the main menu.

In this new version, the main menu scene and the window scene no longer need to know how to switch scenes. We moved a lot of the real logic into the buttons themselves instead.