### PR TITLE
fix transparency in the engine

### DIFF
--- a/seagulls-engine/src/seagulls/pygame/_printer.py
+++ b/seagulls-engine/src/seagulls/pygame/_printer.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from pathlib import Path
 
 import pygame.display
+from pygame import SRCALPHA
 from pygame.font import Font
 
 from seagulls.engine import Surface
@@ -63,11 +64,11 @@ class PygamePrinter(IPrinter):
         s = size.get()
         p = self._get_adjusted_position(position).get()
 
-        square = Surface((s["width"], s["height"]))
+        square = Surface((s["width"], s["height"]), SRCALPHA, 32)
         square.fill((c["r"], c["g"], c["b"]))
 
         center = Surface(
-            (s["width"] - border_size * 2, s["height"] - border_size * 2))
+            (s["width"] - border_size * 2, s["height"] - border_size * 2), SRCALPHA, 32)
 
         square.blit(center, (border_size, border_size))
         square.set_colorkey((0, 0, 0))
@@ -84,7 +85,7 @@ class PygamePrinter(IPrinter):
         s = size.get()
         p = self._get_adjusted_position(position).get()
 
-        square = Surface((s["width"], s["height"]))
+        square = Surface((s["width"], s["height"]), SRCALPHA, 32)
         square.fill((c["r"], c["g"], c["b"]))
         self._get_frame().blit(square, (p["x"], p["y"]))
 
@@ -102,8 +103,7 @@ class PygamePrinter(IPrinter):
 
         sprite_surface = self._load_png(sprite.sprite_grid.file_path)
 
-        unit_surface = Surface((rez["width"], rez["height"]))
-        unit_surface.set_colorkey((0, 0, 0))
+        unit_surface = Surface((rez["width"], rez["height"]), SRCALPHA, 32)
         unit_surface.blit(
             sprite_surface, (0, 0), (pos["x"], pos["y"], rez["width"], rez["height"]))
         scaled_surface = pygame.transform.scale(unit_surface, (s["width"], s["height"]))

--- a/seagulls-engine/src/seagulls/pygame/_surface.py
+++ b/seagulls-engine/src/seagulls/pygame/_surface.py
@@ -2,6 +2,8 @@ import logging
 from abc import abstractmethod
 from typing import Protocol, Tuple
 
+from pygame import SRCALPHA
+
 from seagulls.engine import Surface
 from seagulls.rendering import SizeDict
 
@@ -34,7 +36,7 @@ class PygameSurface(IProvideSurfaces):
         self._background_color = background_color
 
     def get(self) -> Surface:
-        surface = Surface((self._size["width"], self._size["height"]))
+        surface = Surface((self._size["width"], self._size["height"]), SRCALPHA, 32)
         surface.fill(self._background_color)
         return surface
 

--- a/seagulls-engine/src/seagulls/pygame/_window.py
+++ b/seagulls-engine/src/seagulls/pygame/_window.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Tuple
 
 import pygame
+from pygame import SRCALPHA
 
 from seagulls.engine import Surface
 from seagulls.rendering import SizeDict
@@ -57,7 +58,7 @@ class WindowSurface(IProvideSurfaces):
             # Total of padding
             empty_space = abs(needed_width - camera_width)
             # We make a fully filled in surface matching the padding color
-            final_surface = Surface((needed_width, camera_height))
+            final_surface = Surface((needed_width, camera_height), SRCALPHA, 32)
             final_surface.fill(self._padding_color)
             # And then print the camera image in the middle
             final_surface.blit(surface, (empty_space / 2, 0))
@@ -67,7 +68,7 @@ class WindowSurface(IProvideSurfaces):
             # Total of padding
             empty_space = needed_height - camera_height
             # We make a fully filled in surface matching the padding color
-            final_surface = Surface((camera_width, needed_height))
+            final_surface = Surface((camera_width, needed_height), SRCALPHA, 32)
             final_surface.fill(self._padding_color)
             # And then print the camera image in the middle
             final_surface.blit(surface, (0, empty_space / 2))


### PR DESCRIPTION
anywhere we create a `Surface` object, I'm making sure to set it as a transparent object. Then took out the logic for using colorkeys since that was hardcoded to black and was causing weird artifacts. This fixes rendering issues in linux/windows and fixes the ability to use any transparent sprite on mac.